### PR TITLE
Check default locations if no --config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ ring = "0.16"
 log = { version = "0.4.17", features = ["std", "serde"] }
 time = "0.3.17"
 uuid = { version = "1.2.2", features = ["v4", "fast-rng"] }
+directories = "4.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use crate::scanner::Scanner;
 fn main() -> Result<(), Error> {
     let config = match parser::args().config {
         Some(config_path) => Config::load(&config_path)?,
-        None => Default::default(),
+        None => Config::default_load()?,
     };
 
     Logger::init(&config.logger)?;


### PR DESCRIPTION
Uses directories crate to provide a cross platform approach to finding configuration directories.
Linux: ${XDG_CONFIG_HOME}
Windows: {FOLDERID_RoamingAppData}
MacOS: $HOME/Library/Application Support

Falls back to `/etc/leaktk/config.toml' on unix systems

Fall back to the Default::default()