### PR TITLE
Create signed builds and publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,12 @@ permissions:
   packages: write
 
 jobs:
-#  tests:
-#    uses: ./.github/workflows/testing.yml
+  tests:
+    uses: ./.github/workflows/testing.yml
 
   goreleaser:
     name: Create release artifacts
-    # needs: [ tests ]
+    needs: [ tests ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,12 @@ permissions:
   packages: write
 
 jobs:
-  tests:
-    uses: ./.github/workflows/testing.yml
+#  tests:
+#    uses: ./.github/workflows/testing.yml
 
   goreleaser:
     name: Create release artifacts
-    needs: [ tests ]
+#    needs: [ tests ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,12 @@ jobs:
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # pin@v5
         with:
           go-version: stable
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # pin@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@9ed2f89a662bf1735a48bc8557fd212fa902bebf #pin@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: goreleaser
+
+env:
+  GO_VERSION: '1.22'
+  GO111MODULE: on
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  tests:
+    uses: ./.github/workflows/testing.yml
+
+  goreleaser:
+    name: Create release artifacts
+    needs: [ tests ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # pin@v5
+        with:
+          go-version: stable
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@9ed2f89a662bf1735a48bc8557fd212fa902bebf #pin@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
   packages: write
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,10 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # pin@v3
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@9ed2f89a662bf1735a48bc8557fd212fa902bebf #pin@v6
+        uses: goreleaser/goreleaser-action@9ed2f89a662bf1735a48bc8557fd212fa902bebf # pin@v6
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,12 +14,12 @@ permissions:
   packages: write
 
 jobs:
-  tests:
-    uses: ./.github/workflows/testing.yml
+#  tests:
+#    uses: ./.github/workflows/testing.yml
 
   goreleaser:
     name: Create release artifacts
-    needs: [ tests ]
+    # needs: [ tests ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -5,7 +5,7 @@ defaults:
     shell: bash
 
 env:
-  GO_VERSION: '1.21'
+  GO_VERSION: '1.22'
   GO111MODULE: on
 
 on:

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ leaktk-scanner
 
 # Go workspace file
 go.work
+# Added by goreleaser init:
+dist/

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,3 +15,6 @@ linters:
     - staticcheck
     - unused
     - gosec
+
+run:
+  timeout: 3m

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -42,11 +42,19 @@ changelog:
 
 dockers:
   - image_templates:
-      - "thewizzy/scanner:{{ .Tag }}"
-      - "thewizzy/scanner:v{{ .Major }}"
-      - "thewizzy/scanner:v{{ .Major }}.{{ .Minor }}"
-      - "thewizzy/scanner:latest"
-    use: podman
+      - "ghcr.io/thewizzy/scanner:{{ .Tag }}"
+      - "ghcr.io/thewizzy/scanner:v{{ .Major }}"
+      - "ghcr.io/thewizzy/scanner:v{{ .Major }}.{{ .Minor }}"
+      - "ghcr.io/thewizzy/scanner:latest"
+    use: docker
+    dockerfile: Containerfile
+    build_flag_templates:
+      - --label=org.opencontainers.image.title={{ .ProjectName }}
+      - --label=org.opencontainers.image.description={{ .ProjectName }}
+      - --label=org.opencontainers.image.version={{ .Version }}
+      - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+      - --label=org.opencontainers.image.licenses=MIT
 
 release:
   footer: >-

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -57,12 +57,12 @@ dockers:
       - --label=org.opencontainers.image.revision={{ .FullCommit }}
       - --label=org.opencontainers.image.licenses=MIT
   - image_templates:
-      - "ghcr.io/thewizzy/{{ .ProjectName }}:{{ .Version }}-arm64v8"
+      - "ghcr.io/thewizzy/{{ .ProjectName }}:{{ .Version }}-arm64"
     use: buildx
     goarch: arm64
     dockerfile: Containerfile
     build_flag_templates:
-      - --platform=linux/arm64/v8
+      - --platform=linux/arm64
       - --label=org.opencontainers.image.title={{ .ProjectName }}
       - --label=org.opencontainers.image.description={{ .ProjectName }}
       - --label=org.opencontainers.image.version={{ .Version }}
@@ -73,11 +73,11 @@ docker_manifests:
   - name_template: "ghcr.io/thewizzy/{{ .ProjectName }}:{{ .Version }}"
     image_templates:
       - "ghcr.io/thewizzy/{{ .ProjectName }}:{{ .Version }}-amd64"
-      - "ghcr.io/thewizzy/{{ .ProjectName }}:{{ .Version }}-arm64v8"
+      - "ghcr.io/thewizzy/{{ .ProjectName }}:{{ .Version }}-arm64"
   - name_template: "ghcr.io/thewizzy/{{ .ProjectName }}:latest"
     image_templates:
       - "ghcr.io/thewizzy/{{ .ProjectName }}:{{ .Version }}-amd64"
-      - "ghcr.io/thewizzy/{{ .ProjectName }}:{{ .Version }}-arm64v8"
+      - "ghcr.io/thewizzy/{{ .ProjectName }}:{{ .Version }}-arm64"
 
 docker_signs:
   - cmd: cosign

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,19 +45,48 @@ changelog:
 
 dockers:
   - image_templates:
-      - "ghcr.io/thewizzy/scanner:{{ .Tag }}"
-      - "ghcr.io/thewizzy/scanner:v{{ .Major }}"
-      - "ghcr.io/thewizzy/scanner:v{{ .Major }}.{{ .Minor }}"
-      - "ghcr.io/thewizzy/scanner:latest"
-    use: docker
+      - "ghcr.io/thewizzy/{{ .ProjectName }}:{{ .Version }}-amd64"
+    use: buildx
     dockerfile: Containerfile
     build_flag_templates:
+      - --platform=linux/amd64
       - --label=org.opencontainers.image.title={{ .ProjectName }}
       - --label=org.opencontainers.image.description={{ .ProjectName }}
       - --label=org.opencontainers.image.version={{ .Version }}
       - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
       - --label=org.opencontainers.image.revision={{ .FullCommit }}
       - --label=org.opencontainers.image.licenses=MIT
+  - image_templates:
+      - "ghcr.io/thewizzy/{{ .ProjectName }}:{{ .Version }}-arm64v8"
+    use: buildx
+    goarch: arm64
+    dockerfile: Containerfile
+    build_flag_templates:
+      - --platform=linux/arm64/v8
+      - --label=org.opencontainers.image.title={{ .ProjectName }}
+      - --label=org.opencontainers.image.description={{ .ProjectName }}
+      - --label=org.opencontainers.image.version={{ .Version }}
+      - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+      - --label=org.opencontainers.image.licenses=MIT
+docker_manifests:
+  - name_template: "ghcr.io/thewizzy/{{ .ProjectName }}:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/thewizzy/{{ .ProjectName }}:{{ .Version }}-amd64"
+      - "ghcr.io/thewizzy/{{ .ProjectName }}:{{ .Version }}-arm64v8"
+  - name_template: "ghcr.io/thewizzy/{{ .ProjectName }}:latest"
+    image_templates:
+      - "ghcr.io/thewizzy/{{ .ProjectName }}:{{ .Version }}-amd64"
+      - "ghcr.io/thewizzy/{{ .ProjectName }}:{{ .Version }}-arm64v8"
+
+docker_signs:
+  - cmd: cosign
+    artifacts: all
+    output: true
+    args:
+      - "sign"
+      - "${artifact}"
+      - "--yes"
 
 signs:
   - cmd: cosign

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,7 +45,7 @@ changelog:
 
 dockers:
   - image_templates:
-      - "ghcr.io/thewizzy/{{ .ProjectName }}:{{ .Version }}-amd64"
+      - "ghcr.io/thewizzy/{{ .ProjectName }}:v{{ .Version }}-amd64"
     use: buildx
     dockerfile: Containerfile
     build_flag_templates:
@@ -57,7 +57,7 @@ dockers:
       - --label=org.opencontainers.image.revision={{ .FullCommit }}
       - --label=org.opencontainers.image.licenses=MIT
   - image_templates:
-      - "ghcr.io/thewizzy/{{ .ProjectName }}:{{ .Version }}-arm64"
+      - "ghcr.io/thewizzy/{{ .ProjectName }}:v{{ .Version }}-arm64"
     use: buildx
     goarch: arm64
     dockerfile: Containerfile
@@ -70,14 +70,22 @@ dockers:
       - --label=org.opencontainers.image.revision={{ .FullCommit }}
       - --label=org.opencontainers.image.licenses=MIT
 docker_manifests:
-  - name_template: "ghcr.io/thewizzy/{{ .ProjectName }}:{{ .Version }}"
+  - name_template: "ghcr.io/thewizzy/{{ .ProjectName }}:v{{ .Version }}"
     image_templates:
-      - "ghcr.io/thewizzy/{{ .ProjectName }}:{{ .Version }}-amd64"
-      - "ghcr.io/thewizzy/{{ .ProjectName }}:{{ .Version }}-arm64"
+      - "ghcr.io/thewizzy/{{ .ProjectName }}:v{{ .Version }}-amd64"
+      - "ghcr.io/thewizzy/{{ .ProjectName }}:v{{ .Version }}-arm64"
   - name_template: "ghcr.io/thewizzy/{{ .ProjectName }}:latest"
     image_templates:
-      - "ghcr.io/thewizzy/{{ .ProjectName }}:{{ .Version }}-amd64"
-      - "ghcr.io/thewizzy/{{ .ProjectName }}:{{ .Version }}-arm64"
+      - "ghcr.io/thewizzy/{{ .ProjectName }}:v{{ .Version }}-amd64"
+      - "ghcr.io/thewizzy/{{ .ProjectName }}:v{{ .Version }}-arm64"
+  - name_template: "ghcr.io/thewizzy/{{ .ProjectName }}:v{{ .Major }}"
+    image_templates:
+      - "ghcr.io/thewizzy/{{ .ProjectName }}:v{{ .Version }}-amd64"
+      - "ghcr.io/thewizzy/{{ .ProjectName }}:v{{ .Version }}-arm64"
+  - name_template: "ghcr.io/thewizzy/{{ .ProjectName }}:v{{ .Major }}.{{ .Minor }}"
+    image_templates:
+      - "ghcr.io/thewizzy/{{ .ProjectName }}:v{{ .Version }}-amd64"
+      - "ghcr.io/thewizzy/{{ .ProjectName }}:v{{ .Version }}-arm64"
 
 docker_signs:
   - cmd: cosign

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,56 @@
+version: 2
+
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+    # you may remove this if you don't need go generate
+    - go generate ./...
+
+builds:
+  - binary: scanner
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    ldflags:
+      - -X github.com/leaktk/scanner/cmd.Version={{.Version}} -X github.com/leaktk/scanner/cmd.Commit={{.Commit}}
+
+archives:
+  - formats: tar.gz
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+      - goos: windows
+        formats: zip
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+
+dockers:
+  - image_templates:
+      - "thewizzy/scanner:{{ .Tag }}"
+      - "thewizzy/scanner:v{{ .Major }}"
+      - "thewizzy/scanner:v{{ .Major }}.{{ .Minor }}"
+      - "thewizzy/scanner:latest"
+    use: podman
+
+release:
+  footer: >-
+
+    ---
+
+    Released by [GoReleaser](https://github.com/goreleaser/goreleaser).

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,6 +15,9 @@ builds:
       - linux
       - windows
       - darwin
+    goarch:
+      - amd64
+      - arm64
     ldflags:
       - -X github.com/leaktk/scanner/cmd.Version={{.Version}} -X github.com/leaktk/scanner/cmd.Commit={{.Commit}}
 
@@ -55,6 +58,20 @@ dockers:
       - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
       - --label=org.opencontainers.image.revision={{ .FullCommit }}
       - --label=org.opencontainers.image.licenses=MIT
+
+signs:
+  - cmd: cosign
+    signature: "${artifact}.sig"
+    certificate: "${artifact}.pem"
+    args:
+      - sign-blob
+      - '--oidc-provider=github-actions'
+      - '--output-certificate=${certificate}'
+      - '--output-signature=${signature}'
+      - '${artifact}'
+      - --yes
+    artifacts: all
+    output: true
 
 release:
   footer: >-

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,3 @@
+FROM scratch
+COPY scanner /usr/local/bin/scanner
+ENTRYPOINT ["/usr/local/bin/scanner"]


### PR DESCRIPTION
When a tag is created goreleaser will build and publish the artifacts, including a container. 
Currently it builds darwin, linux and windows - both arm64 and amd64. These are signed with cosign.
There is a container build but it is not signed yet and only single arch - uploading to gcr.

This is a proof of concept for leaktk/scanner.